### PR TITLE
using own kanboard which has minute granularity

### DIFF
--- a/kanboard/docker-compose.yml
+++ b/kanboard/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   kanboard:
-    image: kanboard/kanboard:v1.2.44
+    image: ghcr.io/jogi-k/kanboard:v1.2.46-minute-gran-01
     ports:
       - "8880:80"
       - "443:443"


### PR DESCRIPTION
Change docker-compose to make use of own branch on own fork of kanboard which is capable of showing minute granularity 

closes #6 